### PR TITLE
Display API error details in Streamlit app

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -20,15 +20,16 @@ if submitted:
             json={"q": q, "page_size": page_size},
             timeout=30,
         )
-        resp.raise_for_status()
+        if resp.status_code != 200:
+            st.error(resp.json().get("detail", "Erreur inconnue"))
         data = resp.json()["items"]
 
         st.success(f"{len(data)} résultat(s) trouvé(s)")
 
         for item in data:
             st.markdown(
-                f"""**{item['title']}**  
-                {item.get('date') or ''}  
+                f"""**{item['title']}**
+                {item.get('date') or ''}
                 {item.get('url') or ''}"""
             )
 
@@ -53,7 +54,8 @@ if saved:
             json={"q": q2, "email": email or None},
             timeout=30,
         )
-        resp.raise_for_status()
+        if resp.status_code != 200:
+            st.error(resp.json().get("detail", "Erreur inconnue"))
         st.success("Recherche sauvegardée !")
     except Exception as e:
         st.error(str(e))


### PR DESCRIPTION
## Summary
- Show detailed API errors in Streamlit app when requests fail.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a0bf2c148326944402c224596332