### PR TITLE
test: ensure fast mode fetches only once

### DIFF
--- a/backend/test_service_fast_mode.py
+++ b/backend/test_service_fast_mode.py
@@ -1,0 +1,10 @@
+from unittest.mock import patch
+
+from backend import service
+
+
+def test_fast_mode_calls_fetch_once():
+    query = "dummy"
+    with patch("backend.service._fetch_list_page", return_value=([], False)) as mock_fetch:
+        service.search_offers(query=query, page=3, fast_mode=True)
+        mock_fetch.assert_called_once_with(query, 3)


### PR DESCRIPTION
## Summary
- add pytest verifying `search_offers` in fast mode fetches only the requested page

## Testing
- `pytest backend/test_service_fast_mode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b889465370832689fd5a965971d7a1