### PR TITLE
Add pagination deduplication test

### DIFF
--- a/test_search.py
+++ b/test_search.py
@@ -1,10 +1,10 @@
-
 import requests
 
-resp = requests.post(
-    "http://127.0.0.1:8001/search",
-    json={"q": "analyste", "page_size": 50, "page": 1},
-    timeout=30,
-)
-print(resp.status_code)
-print(resp.json())
+if __name__ == "__main__":
+    resp = requests.post(
+        "http://127.0.0.1:8001/search",
+        json={"q": "analyste", "page_size": 50, "page": 1},
+        timeout=30,
+    )
+    print(resp.status_code)
+    print(resp.json())

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,26 @@
+import backend.service as service
+
+def fake_fetch_list_page(query: str, page: int):
+    pages = {
+        1: ([
+            {"id": "1", "title": "A", "date": "3 Jan 2024"},
+            {"id": "2", "title": "B", "date": "2 Jan 2024"},
+        ], True),
+        2: ([
+            {"id": "2", "title": "B bis", "date": "2 Jan 2024"},  # duplicate
+            {"id": "3", "title": "C", "date": "1 Jan 2024"},
+        ], True),
+        3: ([
+            {"id": "4", "title": "D", "date": "31 Dec 2023"},
+            {"id": "5", "title": "E", "date": "30 Dec 2023"},
+        ], False),
+    }
+    return pages.get(page, ([], False))
+
+def test_pagination_no_overlap(monkeypatch):
+    monkeypatch.setattr(service, "_fetch_list_page", fake_fetch_list_page)
+    page1 = service.search_offers("analyste", page_size=2, page=1)
+    page2 = service.search_offers("analyste", page_size=2, page=2)
+    ids1 = {service.extract_offer_id(o) for o in page1}
+    ids2 = {service.extract_offer_id(o) for o in page2}
+    assert ids1.isdisjoint(ids2)


### PR DESCRIPTION
## Summary
- avoid executing the manual search script during test runs
- add a unit test ensuring each search page returns unique offer IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b88a0f68608326a172c18ee846a68f