### PR TITLE
Optimize backend pagination cache with parallel fetches

### DIFF
--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -40,9 +40,9 @@ def test_cache_prevents_refetch(monkeypatch):
 
     monkeypatch.setattr(service, "_fetch_list_page", tracked_fetch)
     page1 = service.search_offers("analyste", page_size=2, page=1)
-    assert calls == [1, 2, 3]
+    assert calls == [1, 2]
     page2 = service.search_offers("analyste", page_size=2, page=2)
-    assert calls == [1, 2, 3]
+    assert calls == [1, 2, 3, 4]
     ids1 = {service.extract_offer_id(o) for o in page1}
     ids2 = {service.extract_offer_id(o) for o in page2}
     assert ids1.isdisjoint(ids2)


### PR DESCRIPTION
## Summary
- Cache search results along with the last fetched site page
- Fetch only required site pages on demand and parallelize additional page retrieval
- Update pagination test expectations for new caching strategy

## Testing
- `pytest -q`
- `python - <<'PY'
from backend import service
try:
    service.search_offers("test", page_size=50, page=1, refresh_cache=True)
except Exception as e:
    print('error:', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b89805fcc08326ab69541780e84e2b