### PR TITLE
Refactor offer search to use limit instead of pagination

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -39,8 +39,7 @@ app.add_middleware(
 
 class SearchQuery(BaseModel):
     q: Optional[str] = None
-    page_size: int = 50
-    page: int = 1
+    limit: int = 50
 
 
 class SaveSearch(BaseModel):
@@ -65,7 +64,7 @@ def post_search(body: SearchQuery) -> Dict[str, Any]:
     Appelle la recherche distante et renvoie une liste normalisée.
     """
     try:
-        offers = search_offers(query=body.q, page_size=body.page_size, page=body.page)
+        offers = search_offers(query=body.q, limit=body.limit)
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -81,7 +80,7 @@ def post_search(body: SearchQuery) -> Dict[str, Any]:
             }
         )
     # pas de total fiable côté site -> on expose seulement la page actuelle
-    return {"items": result, "page": body.page, "page_size": body.page_size}
+    return {"items": result, "limit": body.limit}
 
 
 @app.post("/save_search")

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -38,7 +38,7 @@ def send_ntfy(title: str, message: str):
 def check_once():
     con = get_conn(); cur = con.cursor()
     for (query, email) in cur.execute("SELECT query, email FROM saved_searches"):
-        offers = search_offers(query=query, page_size=50)
+        offers = search_offers(query=query, limit=50)
         # Load seen into set
         cur2 = con.cursor()
         cur2.execute("SELECT offer_id FROM seen")

--- a/backend/test_service_fast_mode.py
+++ b/backend/test_service_fast_mode.py
@@ -6,5 +6,5 @@ from backend import service
 def test_fast_mode_calls_fetch_once():
     query = "dummy"
     with patch("backend.service._fetch_list_page", return_value=([], False)) as mock_fetch:
-        service.search_offers(query=query, page=3, fast_mode=True)
-        mock_fetch.assert_called_once_with(query, 3)
+        service.search_offers(query=query, fast_mode=True)
+        mock_fetch.assert_called_once_with(query, 1)

--- a/test_search.py
+++ b/test_search.py
@@ -3,7 +3,7 @@ import requests
 if __name__ == "__main__":
     resp = requests.post(
         "http://127.0.0.1:8001/search",
-        json={"q": "analyste", "page_size": 50, "page": 1},
+        json={"q": "analyste", "limit": 50},
         timeout=30,
     )
     print(resp.status_code)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,18 +1,28 @@
 import backend.service as service
 
+
 PAGES = {
-    1: ([
-        {"id": "1", "title": "A", "date": "3 Jan 2024"},
-        {"id": "2", "title": "B", "date": "2 Jan 2024"},
-    ], True),
-    2: ([
-        {"id": "2", "title": "B bis", "date": "2 Jan 2024"},  # duplicate
-        {"id": "3", "title": "C", "date": "1 Jan 2024"},
-    ], True),
-    3: ([
-        {"id": "4", "title": "D", "date": "31 Dec 2023"},
-        {"id": "5", "title": "E", "date": "30 Dec 2023"},
-    ], False),
+    1: (
+        [
+            {"id": "1", "title": "A", "date": "2024-01-03"},
+            {"id": "2", "title": "B", "date": "2024-01-02"},
+        ],
+        True,
+    ),
+    2: (
+        [
+            {"id": "2", "title": "B bis", "date": "2024-01-02"},  # duplicate
+            {"id": "3", "title": "C", "date": "2024-01-01"},
+        ],
+        True,
+    ),
+    3: (
+        [
+            {"id": "4", "title": "D", "date": "2023-12-31"},
+            {"id": "5", "title": "E", "date": "2023-12-30"},
+        ],
+        False,
+    ),
 }
 
 
@@ -20,29 +30,13 @@ def fake_fetch_list_page(query: str, page: int):
     return PAGES.get(page, ([], False))
 
 
-def test_pagination_no_overlap(monkeypatch):
+def test_limit(monkeypatch):
     service._SEARCH_CACHE.clear()
     monkeypatch.setattr(service, "_fetch_list_page", fake_fetch_list_page)
-    page1 = service.search_offers("analyste", page_size=2, page=1)
-    page2 = service.search_offers("analyste", page_size=2, page=2)
-    ids1 = {service.extract_offer_id(o) for o in page1}
-    ids2 = {service.extract_offer_id(o) for o in page2}
-    assert ids1.isdisjoint(ids2)
+    results = service.search_offers("analyste", limit=5)
+    assert len(results) == 5
+    ids = [service.extract_offer_id(o) for o in results]
+    assert len(set(ids)) == 5
+    dates = [service.extract_date(o) for o in results]
+    assert dates == sorted(dates, reverse=True)
 
-
-def test_cache_prevents_refetch(monkeypatch):
-    service._SEARCH_CACHE.clear()
-    calls = []
-
-    def tracked_fetch(query: str, page: int):
-        calls.append(page)
-        return fake_fetch_list_page(query, page)
-
-    monkeypatch.setattr(service, "_fetch_list_page", tracked_fetch)
-    page1 = service.search_offers("analyste", page_size=2, page=1)
-    assert calls == [1, 2]
-    page2 = service.search_offers("analyste", page_size=2, page=2)
-    assert calls == [1, 2, 3, 4]
-    ids1 = {service.extract_offer_id(o) for o in page1}
-    ids2 = {service.extract_offer_id(o) for o in page2}
-    assert ids1.isdisjoint(ids2)


### PR DESCRIPTION
## Summary
- replace page/page_size with limit in backend service
- cache results per query and fetch pages until limit reached
- add unit test verifying limit returns unique sorted offers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b89f82a6b8832695b08faef389024a