### PR TITLE
Expose organization name and logo in search results

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -71,12 +71,16 @@ def post_search(body: SearchQuery) -> Dict[str, Any]:
 
     result = []
     for o in offers:
+        org = o.get("org") if isinstance(o, dict) else None
+        logo = o.get("logo") if isinstance(o, dict) else None
         result.append(
             {
                 "id": extract_offer_id(o) if isinstance(o, dict) else None,
                 "title": extract_title(o) if isinstance(o, dict) else "",
                 "date": extract_date(o) if isinstance(o, dict) else None,
                 "url": extract_url(o) if isinstance(o, dict) else None,
+                "organization": org,
+                "logo": logo,
                 "raw": o,
             }
         )

--- a/backend/service.py
+++ b/backend/service.py
@@ -192,12 +192,24 @@ def _fetch_list_page(query: str, page: int) -> Tuple[List[Dict[str, Any]], bool]
                 break
         iso_date = _parse_date_fr(date_text) if date_text else None
 
+        org_name = None
+        detail = card.select_one(".fr-card__detail")
+        if detail:
+            org_name = detail.get_text(strip=True)
+
+        logo_url = None
+        img = card.select_one("img")
+        if img and img.get("src"):
+            logo_url = _to_absolute(img.get("src"))
+
         results.append(
             {
                 "id": oid,
                 "title": title,
                 "date": iso_date,          # ISO (YYYY-MM-DD) ou None
                 "url": href,               # URL absolue
+                "org": org_name,
+                "logo": logo_url,
             }
         )
 

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -97,8 +97,22 @@ def render_results() -> None:
             title = it.get("title") or "Offre"
             url = it.get("url") or ""
             date_txt = fmt_date(it.get("date"))
+            org = it.get("organization")
+            logo = it.get("logo")
             with st.container(border=True):
-                st.markdown(f"**{title}**")
+                if logo:
+                    col_logo, col_main = st.columns([1, 5])
+                    with col_logo:
+                        st.image(logo, width=80)
+                    with col_main:
+                        st.markdown(f"**{title}**")
+                        if org:
+                            st.caption(org)
+                else:
+                    st.markdown(f"**{title}**")
+                    if org:
+                        st.caption(org)
+
                 meta_parts = []
                 if date_txt:
                     meta_parts.append(f"📅 {date_txt}")

--- a/tests/test_main_search_fields.py
+++ b/tests/test_main_search_fields.py
@@ -1,0 +1,22 @@
+from unittest.mock import patch
+
+from backend.main import post_search, SearchQuery
+
+
+def test_post_search_includes_org_logo():
+    sample_offers = [
+        {
+            "id": "1",
+            "title": "A",
+            "date": "2024-01-01",
+            "url": "http://example.com/a",
+            "org": "Org A",
+            "logo": "http://example.com/logo.png",
+        }
+    ]
+    with patch("backend.main.search_offers", return_value=sample_offers):
+        res = post_search(SearchQuery(q="test", limit=1))
+
+    assert res["items"][0]["organization"] == "Org A"
+    assert res["items"][0]["logo"] == "http://example.com/logo.png"
+


### PR DESCRIPTION
## Summary
- scrape organization name and logo from offer cards
- propagate organization and logo through search API
- show organization name and optional logo in Streamlit UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8a333223883268a77a1dd70e4bbc0