### PR TITLE
Refactor service to use public API

### DIFF
--- a/backend/test_service_fast_mode.py
+++ b/backend/test_service_fast_mode.py
@@ -5,6 +5,6 @@ from backend import service
 
 def test_fast_mode_calls_fetch_once():
     query = "dummy"
-    with patch("backend.service._fetch_list_page", return_value=([], False)) as mock_fetch:
+    with patch("backend.service._fetch_api_page", return_value=[]) as mock_fetch:
         service.search_offers(query=query, fast_mode=True)
-        mock_fetch.assert_called_once_with(query, 1)
+        mock_fetch.assert_called_once_with(query, 1, 50)

--- a/tests/test_integration_api.py
+++ b/tests/test_integration_api.py
@@ -1,0 +1,12 @@
+import pytest
+import requests
+
+from backend import service
+
+
+def test_faulty_query_returns_many_offers():
+    try:
+        results = service.search_offers("dats scientist", limit=40, refresh_cache=True)
+    except (RuntimeError, requests.exceptions.RequestException) as exc:
+        pytest.skip(f"API unreachable: {exc}")
+    assert len(results) > 20

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -2,37 +2,41 @@ import backend.service as service
 
 
 PAGES = {
-    1: (
-        [
-            {"id": "1", "title": "A", "date": "2024-01-03"},
-            {"id": "2", "title": "B", "date": "2024-01-02"},
-        ],
-        True,
-    ),
-    2: (
-        [
-            {"id": "2", "title": "B bis", "date": "2024-01-02"},  # duplicate
-            {"id": "3", "title": "C", "date": "2024-01-01"},
-        ],
-        True,
-    ),
-    3: (
-        [
-            {"id": "4", "title": "D", "date": "2023-12-31"},
-            {"id": "5", "title": "E", "date": "2023-12-30"},
-        ],
-        False,
-    ),
+    1: [
+        {"id": "1", "title": "A", "date": "2024-01-03"},
+        {"id": "2", "title": "B", "date": "2024-01-02"},
+    ],
+    2: [
+        {"id": "2", "title": "B bis", "date": "2024-01-02"},  # duplicate
+        {"id": "3", "title": "C", "date": "2024-01-01"},
+    ],
+    3: [
+        {"id": "4", "title": "D", "date": "2023-12-31"},
+        {"id": "5", "title": "E", "date": "2023-12-30"},
+    ],
 }
 
 
-def fake_fetch_list_page(query: str, page: int):
-    return PAGES.get(page, ([], False))
+def fake_fetch_api_page(query: str, page: int, per_page: int):
+    items = list(PAGES.get(page, []))
+    max_page = max(PAGES)
+    if page < max_page:
+        # pad to per_page to simulate presence of next page
+        filler_count = max(0, per_page - len(items))
+        for i in range(filler_count):
+            items.append(
+                {
+                    "id": f"dummy-{page}-{i}",
+                    "title": "X",
+                    "date": "2000-01-01",
+                }
+            )
+    return items
 
 
 def test_limit(monkeypatch):
     service._SEARCH_CACHE.clear()
-    monkeypatch.setattr(service, "_fetch_list_page", fake_fetch_list_page)
+    monkeypatch.setattr(service, "_fetch_api_page", fake_fetch_api_page)
     results = service.search_offers("analyste", limit=5)
     assert len(results) == 5
     ids = [service.extract_offer_id(o) for o in results]


### PR DESCRIPTION
## Summary
- replace HTML scraping with `_fetch_api_page` hitting the official API
- update search logic, caching and fast mode to rely on API responses
- add integration test ensuring a typo query still returns many offers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb34336320832685e8cd86fc0272f4