### PR TITLE
Use standard User-Agent for API requests

### DIFF
--- a/backend/service.py
+++ b/backend/service.py
@@ -87,7 +87,7 @@ def _fetch_api_page(query: str, page: int, per_page: int) -> List[Dict[str, Any]
     session.mount("https://", adapter)
     session.headers.update(
         {
-            "User-Agent": "JobFinder/1.0 (+https://github.com/OlivierG1729/jobfinder)",
+            "User-Agent": "Mozilla/5.0",
             "Accept": "application/json",
         }
     )


### PR DESCRIPTION
## Summary
- use a generic browser User-Agent when fetching CSP API pages

## Testing
- `pytest`
- `uvicorn backend.main:app --port 8001 --log-level warning &`
- `python - <<'PY'
import requests, json
resp = requests.post('http://127.0.0.1:8001/search', json={'q':'dats scientist','limit':50}, timeout=30)
print('status', resp.status_code)
try:
    data = resp.json()
    print('items', len(data.get('items', [])))
except ValueError as exc:
    print('non-json response', resp.text[:100])
PY`
- `python - <<'PY'
import requests
API_URL='https://choisirleservicepublic.gouv.fr/api/offres'
params={'q':'dats scientist','page':1,'limit':50}
headers={'User-Agent':'Mozilla/5.0','Accept':'application/json'}
resp = requests.get(API_URL, params=params, headers=headers, timeout=10)
print(resp.status_code)
print(resp.text[:100])
try:
    data = resp.json()
    print('items direct', len(data.get('items') or data.get('results') or []))
except Exception as e:
    print('no json', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bb392c37348326ad1632327eff4776